### PR TITLE
fix(frontend): fix having to sign in on app refresh

### DIFF
--- a/packages/frontend/src/app.ts
+++ b/packages/frontend/src/app.ts
@@ -95,8 +95,10 @@ export class App {
         // remove the stored keys when feathers-jwt was also deleted,
         // or if the token expired(?)
         if (error.code === 401) {
+          this.viewModelState.onLogout(this.store);
           storedState.authenticated = false;
-          localStorage.setItem('kennelog-store', storedState);
+          storedState.user = {};
+          localStorage.setItem('kennelog-store', JSON.stringify(storedState));
         }
       }
     }

--- a/packages/frontend/src/app.ts
+++ b/packages/frontend/src/app.ts
@@ -80,13 +80,6 @@ export class App {
     this.subscription.unsubscribe();
   }
 
-  async login() {
-    // update viewModelState if authentication was successful
-    const response = await this.api.login();
-    const user = response.user;
-    this.viewModelState.onLogin(this.store, user);
-  }
-
   async activate(): Promise<void> {
     // @ts-ignore
     const storedState = JSON.parse(localStorage.getItem('kennelog-store'));
@@ -96,7 +89,8 @@ export class App {
 
     if (storedState.authenticated) {
       try {
-        this.login();
+        const { user } = await this.api.login();
+        this.viewModelState.onLogin(this.store, user);
       } catch (error) {
         // remove the stored keys when feathers-jwt was also deleted,
         // or if the token expired(?)

--- a/packages/frontend/test/unit/app.spec.ts
+++ b/packages/frontend/test/unit/app.spec.ts
@@ -4,6 +4,7 @@ import { initialState, AppState as State } from '../../src/shared/app-state';
 import { ViewModelState } from '../../src/shared/view-model-state';
 
 const user = { name: 'Nobody', email: 'test@example.com' };
+const authenticatedState = JSON.stringify({ user: user, authenticated: true });
 
 class ApiStub {
   async login() {
@@ -11,13 +12,40 @@ class ApiStub {
   }
 }
 
+class LocalStorageStub {
+  store: any;
+
+  constructor() {
+    this.store = {};
+  }
+
+  clear() {
+    this.store = {};
+  }
+
+  getItem(key) {
+    return this.store[key] || null;
+  }
+
+  setItem(key, value) {
+    this.store[key] = value;
+  }
+
+  removeItem(key) {
+    delete this.store[key];
+  }
+}
+
 describe('Frontend App Component', () => {
+  let localStorage;
   let component;
   let store;
   let vmState: ViewModelState;
   let api;
 
   beforeEach(() => {
+    localStorage = new LocalStorageStub();
+    global.localStorage = localStorage;
     store = new Store<State>(initialState);
     vmState = new ViewModelState(store);
     api = new ApiStub();
@@ -25,13 +53,47 @@ describe('Frontend App Component', () => {
     component = new App(store, vmState, api);
   });
 
-  it('should set ViewModelState.authenticated on login', async () => {
-    await component.login();
+  it('sets `ViewModelState.authenticated` to `true` on login', async () => {
+    localStorage.setItem('kennelog-store', authenticatedState);
+
+    await component.activate();
     expect(vmState.authenticated).toBeTruthy();
   });
 
-  it('should update ViewModelState on login', async () => {
-    await component.login();
+  it('updates `ViewModelState.user` on login', async () => {
+    localStorage.setItem('kennelog-store', authenticatedState);
+    await component.activate();
     expect(vmState.user).toEqual(user);
+  });
+
+  it('updates viewModelState when login fails with 401', async () => {
+    expect.assertions(2);
+
+    component.api.login = () => {
+      const error = new Error('oops');
+      error.code = 401;
+    };
+
+    localStorage.setItem('kennelog-store', authenticatedState);
+    await component.activate();
+    expect(vmState.user).toEqual({});
+    expect(vmState.authenticated).toBe(false);
+  });
+
+  it('updates the localStorage object when login fails with 401', async () => {
+    expect.assertions(1);
+
+    component.api.login = () => {
+      const error = new Error('oops');
+      error.code = 401;
+      throw error;
+    };
+
+    localStorage.setItem('kennelog-store', authenticatedState);
+    await component.activate();
+    const storedState = localStorage.getItem('kennelog-store');
+    expect(storedState).toEqual(
+      JSON.stringify({ user: {}, authenticated: false })
+    );
   });
 });


### PR DESCRIPTION
The issue was that an asynchronous function (App.login) was called
in without the await keyword.

fix: #53 